### PR TITLE
fix Makefile to support SSP

### DIFF
--- a/package/network/utils/wireless-tools/Makefile
+++ b/package/network/utils/wireless-tools/Makefile
@@ -33,6 +33,7 @@ $(call Package/wireless-tools/Default)
   SECTION:=net
   CATEGORY:=Base system
   TITLE:=Tools for manipulating Linux Wireless Extensions
+  DEPENDS:=+SSP_SUPPORT:libssp
 endef
 
 define Package/wireless-tools/description


### PR DESCRIPTION
Package wireless-tools is missing dependencies for the following libraries:
libssp.so.0
Makefile:91: recipe for target '/home/zero/development/openwrt/bin/ar71xx/packages/base/wireless-tools_29-5_ar71xx.ipk' failed

Signed-off-by: Rick Farina (Zero_Chaos) zerochaos@gentoo.org
