### PR TITLE
Ssp fixes for multiple packages

### DIFF
--- a/package/libs/ncurses/Makefile
+++ b/package/libs/ncurses/Makefile
@@ -32,7 +32,7 @@ define Package/libncurses
   CATEGORY:=Libraries
   TITLE:=Terminal handling library
   URL:=http://www.gnu.org/software/ncurses/
-  DEPENDS:= +terminfo
+  DEPENDS:=+SSP_SUPPORT:libssp +terminfo
   VARIANT:=libncurses
 endef
 
@@ -49,6 +49,7 @@ define Package/libncursesw
   CATEGORY:=Libraries
   TITLE:=Terminal handling library (Unicode)
   URL:=http://www.gnu.org/software/ncurses/
+  DEPENDS:=+SSP_SUPPORT:libssp
   VARIANT:=libncursesw
 endef
 

--- a/package/libs/zlib/Makefile
+++ b/package/libs/zlib/Makefile
@@ -24,6 +24,7 @@ define Package/zlib
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=Library implementing the deflate compression method
+  DEPENDS:=+SSP_SUPPORT:libssp
   URL:=http://www.zlib.net/
 endef
 

--- a/package/network/utils/wireless-tools/Makefile
+++ b/package/network/utils/wireless-tools/Makefile
@@ -32,7 +32,9 @@ define Package/wireless-tools
 $(call Package/wireless-tools/Default)
   SECTION:=net
   CATEGORY:=Base system
+  DEPENDS:=+SSP_SUPPORT:libssp
   TITLE:=Tools for manipulating Linux Wireless Extensions
+  DEPENDS:=+SSP_SUPPORT:libssp
 endef
 
 define Package/wireless-tools/description

--- a/package/utils/px5g/Makefile
+++ b/package/utils/px5g/Makefile
@@ -19,7 +19,7 @@ define Package/px5g
   CATEGORY:=Utilities
   TITLE:=X.509 certificate generator (using PolarSSL)
   MAINTAINER:=Jo-Philipp Wich <jow@openwrt.org>
-  DEPENDS:=+libpolarssl
+  DEPENDS:=+SSP_SUPPORT:libssp +libpolarssl
 endef
 
 define Package/px5g/description


### PR DESCRIPTION
ncurses, zlib, wireless-tools, px5g: add dep on libssp when ssp is enabled.  Based on openwrt complaining loudly about the dep being missing during build.

Signed-of-by: Rick Farina