### PR TITLE
tools/e2fsprogs: add a darwin-compat patch

### DIFF
--- a/tools/e2fsprogs/patches/005-darwin-compat.patch
+++ b/tools/e2fsprogs/patches/005-darwin-compat.patch
@@ -1,0 +1,26 @@
+--- a/lib/blkid/blkid_types.h.in
++++ b/lib/blkid/blkid_types.h.in
+@@ -9,6 +9,10 @@
+ 
+ @ASM_TYPES_HEADER@
+ 
++#if __APPLE__
++#include <stdint.h>
++#endif
++
+ #ifdef __U8_TYPEDEF
+ typedef __U8_TYPEDEF __u8;
+ #else
+--- a/lib/ext2fs/ext2_types.h.in
++++ b/lib/ext2fs/ext2_types.h.in
+@@ -9,6 +9,10 @@
+ 
+ @ASM_TYPES_HEADER@
+ 
++#if __APPLE__
++#include <stdint.h>
++#endif
++
+ #ifdef __U8_TYPEDEF
+ typedef __U8_TYPEDEF __u8;
+ #else


### PR DESCRIPTION
On darwin we need to import stdint to get these integer typedefs.