### PR TITLE
mkimage: cross compile fix: pass HOST_*FLAGS in to uboot's makefile

### DIFF
--- a/tools/mkimage/Makefile
+++ b/tools/mkimage/Makefile
@@ -31,8 +31,8 @@ define Host/Prepare
 endef
 
 define Host/Compile
-	$(MAKE) -C $(HOST_BUILD_DIR) defconfig
-	$(MAKE) -C $(HOST_BUILD_DIR) tools-only
+	$(MAKE) -C $(HOST_BUILD_DIR) defconfig   HOSTCFLAGS="$(HOST_CPPFLAGS) $(HOST_CFLAGS)" HOSTLDFLAGS="$(HOST_LDFLAGS)"
+	$(MAKE) -C $(HOST_BUILD_DIR) tools-only  HOSTCFLAGS="$(HOST_CPPFLAGS) $(HOST_CFLAGS)" HOSTLDFLAGS="$(HOST_LDFLAGS)"
 endef
 
 define Host/Install


### PR DESCRIPTION
This is so if someone needs to pass in special host compiler flags (like if they're trying to cross compile on darwin or something), they get passed through to u-boot's makefile correctly.