### PR TITLE
Add initial support for wdr7500v3

### DIFF
--- a/target/linux/ar71xx/image/Makefile
+++ b/target/linux/ar71xx/image/Makefile
@@ -369,7 +369,14 @@ define Device/archer-c7-v2
     DEVICE_PROFILE := ARCHERC7
     TPLINK_HWID := 0xc7000002
 endef
-TARGET_DEVICES += archer-c5-v1 archer-c7-v1 archer-c7-v2
+
+define Device/tl-wdr7500-v3
+    $(Device/tplink-8mlzma)
+    BOARDNAME := ARCHER-C7
+    DEVICE_PROFILE := ARCHERC7
+    TPLINK_HWID := 0x75000003
+endef
+TARGET_DEVICES += archer-c5-v1 archer-c7-v1 archer-c7-v2 tl-wdr7500-v3
 
 define Device/antminer-s1
     $(Device/tplink-8mlzma)


### PR DESCRIPTION
This device is very similar to archer c7 v2, only difference being 8M of flash instead of 16M, and 6 external antennas instead of 3 external + 3 internal.
The silver sticker on the back, however, has no mention of the word "archer", so I've opted to name the images accordingly.

Signed-off-by: Srdjan Rosic <rosic@google.com>