### PR TITLE
Remove existing old link before creating a new one

### DIFF
--- a/toolchain/kernel-headers/Makefile
+++ b/toolchain/kernel-headers/Makefile
@@ -72,7 +72,8 @@ endef
 
 define Host/Prepare
 	$(call Kernel/Prepare/Default)
-	ln -sf linux-$(LINUX_VERSION) $(BUILD_DIR_TOOLCHAIN)/linux
+	rm -f $(BUILD_DIR_TOOLCHAIN)/linux
+	ln -s linux-$(LINUX_VERSION) $(BUILD_DIR_TOOLCHAIN)/linux
 	$(SED) 's/@expr length/@-expr length/' $(HOST_BUILD_DIR)/Makefile
 endef
 


### PR DESCRIPTION
This is needed after a kernel update, otherwise the
new link is written as linux/linux.

Signed-off-by: Stefan Weil sw@weilnetz.de
